### PR TITLE
Fix: duplicate code in ClientContextConfig

### DIFF
--- a/bundles/com.amazonaws.eclipse.core/src/com/amazonaws/eclipse/core/telemetry/ClientContextConfig.java
+++ b/bundles/com.amazonaws.eclipse.core/src/com/amazonaws/eclipse/core/telemetry/ClientContextConfig.java
@@ -63,22 +63,21 @@ public class ClientContextConfig {
         this.clientId = clientId;
     }
 
-    private String eclipseVersion() {
+    private String getVersion(String bundleName) {
         try {
-            Bundle bundle = Platform.getBundle("org.eclipse.platform");
+            Bundle bundle = Platform.getBundle(bundleName);
             return bundle.getVersion().toString();
         } catch (Exception e) {
             return "Unknown";
         }
     }
 
+    private String eclipseVersion() {
+        return getVersion("org.eclipse.platform");
+    }
+
     private String getPluginVersion() {
-        try {
-            Bundle bundle = Platform.getBundle("com.amazonaws.eclipse.core");
-            return bundle.getVersion().toString();
-        } catch (Exception e) {
-            return "Unknown";
-        }
+        return getVersion("com.amazonaws.eclipse.core");
     }
 
     public String getEnvPlatformName() {


### PR DESCRIPTION
Fixing code Guru finding:

Similar code fragments were detected in the same file at the following lines: 67:72, 76:81.
Refactoring can help improve code maintainability. Consider reducing duplicate code by extracting it into a separate method. You can then replace duplicated code with calls to this new method.